### PR TITLE
Refact: added export default object for routes

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,7 +3,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import { Route, Switch } from 'react-router-dom';
 import { Container } from 'react-bootstrap';
 
-import * as ROUTES from 'constants/routes';
+import ROUTES from 'constants/routes';
 
 import * as authActions from 'store/actions/auth';
 

--- a/src/constants/routes.ts
+++ b/src/constants/routes.ts
@@ -24,3 +24,8 @@ export const authenticatedRoutes: IRoute[] = [
     name: 'Sign out'
   }
 ];
+
+export default {
+  defaultRoutes,
+  authenticatedRoutes
+};


### PR DESCRIPTION
Still can't find a supporting difference with this change adding the default export.
As we could still import all of the exported modules as `import * as moduleName from '/'`