### PR TITLE
Refact: constants routes, imports * as -> import {}

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,11 +3,11 @@ import { useDispatch, useSelector } from 'react-redux';
 import { Route, Switch } from 'react-router-dom';
 import { Container } from 'react-bootstrap';
 
-import * as ROUTES from 'constants/routes';
+import { authenticatedRoutes, defaultRoutes } from 'constants/routes';
 
-import * as authActions from 'store/actions/auth';
+import { checkAuth } from 'store/actions/auth';
 
-import * as authSelectors from 'selectors/auth';
+import { selectAuthSignedIn } from 'selectors/auth';
 
 import Home from 'components/Home/Home';
 import Navigation from 'components/Navigation/Navigation';
@@ -17,17 +17,15 @@ import './App.css';
 
 const App: FC = () => {
   const dispatch = useDispatch();
-  const signedIn = useSelector(authSelectors.selectAuthSignedIn);
-  const [routes, setRoutes] = useState(ROUTES.defaultRoutes);
+  const signedIn = useSelector(selectAuthSignedIn);
+  const [routes, setRoutes] = useState(defaultRoutes);
 
   useEffect(() => {
-    dispatch(authActions.checkAuth());
+    dispatch(checkAuth());
   }, [dispatch]);
 
   useEffect(() => {
-    signedIn
-      ? setRoutes([...ROUTES.authenticatedRoutes])
-      : setRoutes([...ROUTES.defaultRoutes]);
+    signedIn ? setRoutes(authenticatedRoutes) : setRoutes(defaultRoutes);
   }, [signedIn]);
 
   return (

--- a/src/containers/Signin/Signin.tsx
+++ b/src/containers/Signin/Signin.tsx
@@ -3,9 +3,13 @@ import { useDispatch, useSelector } from 'react-redux';
 import { RouteComponentProps } from 'react-router';
 import { Button, Form, Alert, Row, Col } from 'react-bootstrap';
 
-import * as authActions from 'store/actions/auth';
+import { signInAuth } from 'store/actions/auth';
 
-import * as authSelectors from 'selectors/auth';
+import {
+  selectAuthSignedInError,
+  selectAuthSigningIn,
+  selectAuthSignedIn
+} from 'selectors/auth';
 
 import useFormFields from 'hooks/formFields';
 
@@ -18,9 +22,9 @@ const Signin: FC<RouteComponentProps> = ({ history }) => {
   const { push } = history;
 
   const dispatch = useDispatch();
-  const error = useSelector(authSelectors.selectAuthSignedInError);
-  const signingIn = useSelector(authSelectors.selectAuthSigningIn);
-  const signedIn = useSelector(authSelectors.selectAuthSignedIn);
+  const error = useSelector(selectAuthSignedInError);
+  const signingIn = useSelector(selectAuthSigningIn);
+  const signedIn = useSelector(selectAuthSignedIn);
 
   const [fields, handleFieldChange] = useFormFields<IFormState>({
     email: '',
@@ -35,7 +39,7 @@ const Signin: FC<RouteComponentProps> = ({ history }) => {
 
   const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
-    dispatch(authActions.signInAuth(email, password));
+    dispatch(signInAuth(email, password));
   };
 
   return (

--- a/src/containers/Signout/Signout.tsx
+++ b/src/containers/Signout/Signout.tsx
@@ -3,17 +3,17 @@ import { useDispatch, useSelector } from 'react-redux';
 import { RouteComponentProps } from 'react-router';
 import { Row, Col } from 'react-bootstrap';
 
-import * as authActions from 'store/actions/auth';
-import * as authSelectors from 'selectors/auth';
+import { signOutAuth } from 'store/actions/auth';
+import { selectAuthSignedIn } from 'selectors/auth';
 
 const Signout: FC<RouteComponentProps> = ({ history }) => {
   const { push } = history;
 
   const dispatch = useDispatch();
-  const signedIn = useSelector(authSelectors.selectAuthSignedIn);
+  const signedIn = useSelector(selectAuthSignedIn);
 
   useEffect(() => {
-    dispatch(authActions.signOutAuth());
+    dispatch(signOutAuth());
   }, [dispatch]);
 
   useEffect(() => {

--- a/src/containers/Signup/Signup.tsx
+++ b/src/containers/Signup/Signup.tsx
@@ -1,11 +1,4 @@
-import React, {
-  FC,
-  useEffect,
-  useState,
-  FormEvent,
-  Fragment,
-  MouseEvent
-} from 'react';
+import React, { FC, useEffect, useState, FormEvent, Fragment } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { RouteComponentProps } from 'react-router';
 import { Alert, Button, Col, Form, ProgressBar, Row } from 'react-bootstrap';
@@ -13,7 +6,17 @@ import zxcvbn from 'zxcvbn';
 
 import { activateAuth, signInAuth, signUpAuth } from 'store/actions/auth';
 
-import * as authSelectors from 'selectors/auth';
+import {
+  selectAuthActivated,
+  selectAuthActivatedError,
+  selectAuthActivating,
+  selectAuthSignedIn,
+  selectAuthSignedInError,
+  selectAuthSignedUp,
+  selectAuthSignedUpError,
+  selectAuthSigningIn,
+  selectAuthSigningUp
+} from 'selectors/auth';
 
 import useFormFields from 'hooks/formFields';
 
@@ -31,17 +34,17 @@ const Signup: FC<RouteComponentProps> = ({ history }) => {
 
   const dispatch = useDispatch();
 
-  const activated = useSelector(authSelectors.selectAuthActivated);
-  const activatedError = useSelector(authSelectors.selectAuthActivatedError);
-  const activating = useSelector(authSelectors.selectAuthActivating);
+  const activated = useSelector(selectAuthActivated);
+  const activatedError = useSelector(selectAuthActivatedError);
+  const activating = useSelector(selectAuthActivating);
 
-  const signedIn = useSelector(authSelectors.selectAuthSignedIn);
-  const signedInError = useSelector(authSelectors.selectAuthSignedInError);
-  const signingIn = useSelector(authSelectors.selectAuthSigningIn);
+  const signedIn = useSelector(selectAuthSignedIn);
+  const signedInError = useSelector(selectAuthSignedInError);
+  const signingIn = useSelector(selectAuthSigningIn);
 
-  const signedUp = useSelector(authSelectors.selectAuthSignedUp);
-  const signedUpError = useSelector(authSelectors.selectAuthSignedUpError);
-  const signingUp = useSelector(authSelectors.selectAuthSigningUp);
+  const signedUp = useSelector(selectAuthSignedUp);
+  const signedUpError = useSelector(selectAuthSignedUpError);
+  const signingUp = useSelector(selectAuthSigningUp);
 
   const [passStr, setPassStr] = useState(0);
   const [error, setError] = useState('');

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -14,7 +14,7 @@ import config from 'config';
 import sagas from 'store/sagas';
 import reducers from 'store/reducers';
 
-import * as serviceWorker from 'serviceWorker';
+import { unregister as serviceWorkerUnregister } from 'serviceWorker';
 
 import 'index.css';
 
@@ -61,4 +61,4 @@ ReactDOM.render(app, document.getElementById('root'));
 // If you want your app to work offline and load faster, you can change
 // unregister() to register() below. Note this comes with some pitfalls.
 // Learn more about service workers: https://bit.ly/CRA-PWA
-serviceWorker.unregister();
+serviceWorkerUnregister();

--- a/src/store/sagas/auth.ts
+++ b/src/store/sagas/auth.ts
@@ -1,9 +1,32 @@
 import { call, fork, put, takeLatest } from 'redux-saga/effects';
 
-import * as authServices from 'services/auth';
+import { activate, check, signIn, signOut, signUp } from 'services/auth';
 
-import * as authActionTypes from 'store/types/auth';
-import * as authActions from 'store/actions/auth';
+import {
+  ACTIVATE_AUTH,
+  CHECK_AUTH,
+  SIGN_IN_AUTH,
+  SIGN_OUT_AUTH,
+  SIGN_UP_AUTH
+} from 'store/types/auth';
+
+import {
+  activatedAuth,
+  activatedErrorAuth,
+  activatingAuth,
+  checkedAuth,
+  checkedErrorAuth,
+  checkingAuth,
+  signedInAuth,
+  signedInErrorAuth,
+  signedOutAuth,
+  signedOutErrorAuth,
+  signedUpAuth,
+  signedUpErrorAuth,
+  signingInAuth,
+  signingOutAuth,
+  signingUpAuth
+} from 'store/actions/auth';
 
 import {
   ISignInAuthAction,
@@ -20,74 +43,74 @@ export default [
 ];
 
 function* signInSaga() {
-  yield takeLatest(authActionTypes.SIGN_IN_AUTH, callSignInSaga);
+  yield takeLatest(SIGN_IN_AUTH, callSignInSaga);
 }
 
 function* callSignInSaga({ payload }: ISignInAuthAction) {
   try {
-    yield put(authActions.signingInAuth());
+    yield put(signingInAuth());
     const { email, password } = payload;
-    yield call(authServices.signIn, email, password);
-    yield put(authActions.signedInAuth());
+    yield call(signIn, email, password);
+    yield put(signedInAuth());
   } catch (err) {
-    yield put(authActions.signedInErrorAuth(err.message));
+    yield put(signedInErrorAuth(err.message));
   }
 }
 
 function* checkAuth() {
-  yield takeLatest(authActionTypes.CHECK_AUTH, callCheckAuthSaga);
+  yield takeLatest(CHECK_AUTH, callCheckAuthSaga);
 }
 
 function* callCheckAuthSaga() {
   try {
-    yield put(authActions.checkingAuth());
-    yield call(authServices.check);
-    yield put(authActions.checkedAuth());
+    yield put(checkingAuth());
+    yield call(check);
+    yield put(checkedAuth());
   } catch (err) {
-    yield put(authActions.checkedErrorAuth(err.message));
+    yield put(checkedErrorAuth(err.message));
   }
 }
 
 function* signOutSaga() {
-  yield takeLatest(authActionTypes.SIGN_OUT_AUTH, callSignOutSaga);
+  yield takeLatest(SIGN_OUT_AUTH, callSignOutSaga);
 }
 
 function* callSignOutSaga() {
   try {
-    yield put(authActions.signingOutAuth());
-    yield call(authServices.signOut);
-    yield put(authActions.signedOutAuth());
+    yield put(signingOutAuth());
+    yield call(signOut);
+    yield put(signedOutAuth());
   } catch (err) {
-    yield put(authActions.signedOutErrorAuth(err.message));
+    yield put(signedOutErrorAuth(err.message));
   }
 }
 
 function* signUpSaga() {
-  yield takeLatest(authActionTypes.SIGN_UP_AUTH, callSignUpSaga);
+  yield takeLatest(SIGN_UP_AUTH, callSignUpSaga);
 }
 
 function* callSignUpSaga({ payload }: ISignUpAuthAction) {
   try {
     const { email, password } = payload;
-    yield put(authActions.signingUpAuth());
-    yield call(authServices.signUp, email, password);
-    yield put(authActions.signedUpAuth());
+    yield put(signingUpAuth());
+    yield call(signUp, email, password);
+    yield put(signedUpAuth());
   } catch (err) {
-    yield put(authActions.signedUpErrorAuth(err.message));
+    yield put(signedUpErrorAuth(err.message));
   }
 }
 
 function* activateSaga() {
-  yield takeLatest(authActionTypes.ACTIVATE_AUTH, callActivateSaga);
+  yield takeLatest(ACTIVATE_AUTH, callActivateSaga);
 }
 
 function* callActivateSaga({ payload }: IActivateAuthAction) {
   try {
     const { email, code } = payload;
-    yield put(authActions.activatingAuth());
-    yield call(authServices.activate, email, code);
-    yield put(authActions.activatedAuth());
+    yield put(activatingAuth());
+    yield call(activate, email, code);
+    yield put(activatedAuth());
   } catch (err) {
-    yield put(authActions.activatedErrorAuth(err.message));
+    yield put(activatedErrorAuth(err.message));
   }
 }

--- a/src/store/types/auth.ts
+++ b/src/store/types/auth.ts
@@ -1,7 +1,7 @@
-export const ACTIVATE_AUTH = '@auth/ACTIVATE_AUTH';
-export const ACTIVATED_AUTH = '@auth/ACTIVATED_AUTH';
-export const ACTIVATED_ERROR_AUTH = '@auth/ACTIVATED_ERROR_AUTH';
-export const ACTIVATING_AUTH = '@auth/ACTIVATING_AUTH';
+export const ACTIVATE_AUTH = '@auth/ACTIVATE';
+export const ACTIVATED_AUTH = '@auth/ACTIVATED';
+export const ACTIVATED_ERROR_AUTH = '@auth/ACTIVATED_ERROR';
+export const ACTIVATING_AUTH = '@auth/ACTIVATING';
 
 export const CHECK_AUTH = '@auth/CHECK';
 export const CHECKED_AUTH = '@auth/CHECKED';


### PR DESCRIPTION
Refact:
- constant routes rather than `setRoutes([...routes])` decided to directly assign to `setRoutes(routes)`
- removed `import * as` as this will import other unnecessary methods/named exports and will clutter the build file i.e additional size.
- standard naming convention for action types