### PR TITLE
Feat: delete note

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3976,6 +3976,16 @@
       "resolved": "https://registry.npmjs.org/connect-history-api-fallback/-/connect-history-api-fallback-1.6.0.tgz",
       "integrity": "sha512-e54B99q/OUoH64zYYRf3HBP5z24G38h5D3qXu23JGRoigpX5Ss4r9ZnDk3g0Z8uQC2x2lPaJ+UlWBc1ZWBWdLg=="
     },
+    "connected-react-router": {
+      "version": "6.5.2",
+      "resolved": "https://registry.npmjs.org/connected-react-router/-/connected-react-router-6.5.2.tgz",
+      "integrity": "sha512-qzsLPZCofSI80fwy+HgxtEgSGS4ndYUUZAWaw1dqaOGPLKX/FVwIOEb7q+hjHdnZ4v5pKZcNv5GG4urjujIoyA==",
+      "requires": {
+        "immutable": "^3.8.1",
+        "prop-types": "^15.7.2",
+        "seamless-immutable": "^7.1.3"
+      }
+    },
     "console-browserify": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.2.0.tgz",
@@ -6717,6 +6727,11 @@
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/immer/-/immer-1.10.0.tgz",
       "integrity": "sha512-O3sR1/opvCDGLEVcvrGTMtLac8GJ5IwZC4puPrLuRj3l7ICKvkmA0vGuU9OW8mV9WIBRnaxp5GJh9IEAaNOoYg=="
+    },
+    "immutable": {
+      "version": "3.8.2",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-3.8.2.tgz",
+      "integrity": "sha1-wkOZUUVbs5kT2vKBN28VMOEErfM="
     },
     "import-cwd": {
       "version": "2.1.0",
@@ -11821,6 +11836,11 @@
         "ajv-errors": "^1.0.0",
         "ajv-keywords": "^3.1.0"
       }
+    },
+    "seamless-immutable": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/seamless-immutable/-/seamless-immutable-7.1.4.tgz",
+      "integrity": "sha512-XiUO1QP4ki4E2PHegiGAlu6r82o5A+6tRh7IkGGTVg/h+UoeX4nFBeCGPOhb4CYjvkqsfm/TUtvOMYC1xmV30A=="
     },
     "select-hose": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "dependencies": {
     "aws-amplify": "^1.2.3",
     "bootstrap": "^4.3.1",
+    "connected-react-router": "^6.5.2",
     "moment": "^2.24.0",
     "react": "^16.11.0",
     "react-bootstrap": "^1.0.0-beta.14",

--- a/src/containers/Note/Add.tsx
+++ b/src/containers/Note/Add.tsx
@@ -1,25 +1,14 @@
-import React, {
-  FC,
-  useRef,
-  ChangeEvent,
-  FormEvent,
-  useState,
-  useEffect
-} from 'react';
+import React, { FC, useRef, ChangeEvent, FormEvent, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { Alert, Button, Col, Form, Row } from 'react-bootstrap';
 import { RouteComponentProps } from 'react-router';
 
-import { addNote, fetchListNote } from 'store/actions/note';
+import { addNote } from 'store/actions/note';
 
 import useFormFields from 'hooks/formFields';
 
 import config from 'config';
-import {
-  selectNoteAdded,
-  selectNoteAdding,
-  selectNoteAddError
-} from 'selectors/note';
+import { selectNoteAdding, selectNoteAddError } from 'selectors/note';
 
 interface IFormFields {
   content: string;
@@ -27,9 +16,7 @@ interface IFormFields {
 
 const MAX_SIZE = config.attachment.MAX_ATTACHMENT_SIZE / 1000000;
 
-const NoteAdd: FC<RouteComponentProps> = ({ history }) => {
-  const { push } = history;
-
+const NoteAdd: FC<RouteComponentProps> = () => {
   const dispatch = useDispatch();
   const file = useRef<File>();
   const [error, setError] = useState('');
@@ -37,16 +24,8 @@ const NoteAdd: FC<RouteComponentProps> = ({ history }) => {
     content: ''
   });
 
-  const added = useSelector(selectNoteAdded);
   const adding = useSelector(selectNoteAdding);
   const addError = useSelector(selectNoteAddError);
-
-  useEffect(() => {
-    if (added) {
-      dispatch(fetchListNote());
-      push('/');
-    }
-  }, [dispatch, added, push]);
 
   const handleFileChange = (event: ChangeEvent<HTMLInputElement>) => {
     file.current = event.target.files![0];

--- a/src/containers/Note/List.tsx
+++ b/src/containers/Note/List.tsx
@@ -8,7 +8,9 @@ import { fetchListNote } from 'store/actions/note';
 import {
   selectNoteListFetching,
   selectNoteListError,
-  selectNoteListFetchedData
+  selectNoteListFetchedData,
+  selectNoteListFetched,
+  selectNoteListInitial
 } from 'selectors/note';
 
 import './styles/List.css';
@@ -19,15 +21,17 @@ const NoteList: FC<RouteComponentProps> = ({ history }) => {
   const { push } = history;
 
   const dispatch = useDispatch();
+  const initial = useSelector(selectNoteListInitial);
+  const fetched = useSelector(selectNoteListFetched);
   const fetching = useSelector(selectNoteListFetching);
   const error = useSelector(selectNoteListError);
   const notes = useSelector(selectNoteListFetchedData);
 
   useEffect(() => {
-    if (!notes.length) {
-      dispatch(fetchListNote());
+    if (!initial) {
+      dispatch(fetchListNote(true));
     }
-  }, [dispatch, notes]);
+  }, [dispatch, initial]);
 
   const handleAddNote = () => {
     push('/notes/add');
@@ -55,7 +59,7 @@ const NoteList: FC<RouteComponentProps> = ({ history }) => {
     ];
   }
 
-  if (notes.length && !fetching && !error) {
+  if (fetched && !fetching && !error) {
     items = notes.map(note => {
       const { noteId, content, createdAt } = note;
       const noteLines = content.split('\n');

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,18 +1,14 @@
 import React from 'react';
-import { createStore, applyMiddleware } from 'redux';
 import { Provider } from 'react-redux';
-import createSagaMiddleware from 'redux-saga';
-import { composeWithDevTools } from 'redux-devtools-extension';
 import ReactDOM from 'react-dom';
-import { BrowserRouter as Router } from 'react-router-dom';
+import { ConnectedRouter as Router } from 'connected-react-router';
 import Amplify from 'aws-amplify';
+
+import configureStore, { history } from 'store';
 
 import App from 'App';
 
 import config from 'config';
-
-import sagas from 'store/sagas';
-import reducers from 'store/reducers';
 
 import { unregister as serviceWorkerUnregister } from 'serviceWorker';
 
@@ -42,15 +38,11 @@ Amplify.configure({
   }
 });
 
-const sagaMiddleware = createSagaMiddleware();
-const enhancer = composeWithDevTools(applyMiddleware(sagaMiddleware));
-const store = createStore(reducers, enhancer);
-
-sagaMiddleware.run(sagas);
+const store = configureStore();
 
 const app = (
   <Provider store={store}>
-    <Router>
+    <Router history={history}>
       <App />
     </Router>
   </Provider>

--- a/src/interfaces/actions/note.ts
+++ b/src/interfaces/actions/note.ts
@@ -3,6 +3,10 @@ import {
   ADDED_ERROR_NOTE,
   ADDED_NOTE,
   ADDING_NOTE,
+  DELETE_NOTE,
+  DELETED_ERROR_NOTE,
+  DELETED_NOTE,
+  DELETING_NOTE,
   FETCH_LIST_NOTE,
   FETCH_NOTE,
   FETCHED_ERROR_LIST_NOTE,
@@ -27,6 +31,7 @@ export interface IAddedErrorNoteAction {
 
 export interface IAddedNoteAction {
   type: typeof ADDED_NOTE;
+  payload?: boolean;
 }
 
 export interface IAddingNoteAction {
@@ -35,6 +40,7 @@ export interface IAddingNoteAction {
 
 export interface IFetchListNoteAction {
   type: typeof FETCH_LIST_NOTE;
+  payload?: boolean;
 }
 
 export interface IFetchedErrorListNoteAction {
@@ -44,7 +50,7 @@ export interface IFetchedErrorListNoteAction {
 
 export interface IFetchedListNoteAction {
   type: typeof FETCHED_LIST_NOTE;
-  payload: INote[];
+  payload: { fetched?: boolean; notes: INote[] };
 }
 
 export interface IFetchingListNoteAction {
@@ -65,4 +71,23 @@ export interface IFetchedNoteAction {
 }
 export interface IFetchingNoteAction {
   type: typeof FETCHING_NOTE;
+}
+
+export interface IDeleteNoteAction {
+  type: typeof DELETE_NOTE;
+  payload: { id: string; fileName?: string };
+}
+
+export interface IDeletedErrorNoteAction {
+  type: typeof DELETED_ERROR_NOTE;
+  payload: string;
+}
+
+export interface IDeletedNoteAction {
+  type: typeof DELETED_NOTE;
+  payload?: boolean;
+}
+
+export interface IDeletingNoteAction {
+  type: typeof DELETING_NOTE;
 }

--- a/src/interfaces/state/note.ts
+++ b/src/interfaces/state/note.ts
@@ -13,6 +13,7 @@ export default interface INoteState {
     error: string;
     // TODO: Change this to data: D[] or extend IDataState, if going to be generic
     notes: INote[];
+    initial: boolean;
   };
   fetch: {
     fetching: boolean;
@@ -20,5 +21,10 @@ export default interface INoteState {
     error: string;
     // TODO: Change this to data: D or extends IDataState, if going to be generic
     note?: INote;
+  };
+  delete: {
+    deleting: boolean;
+    deleted: boolean;
+    error: string;
   };
 }

--- a/src/selectors/note.ts
+++ b/src/selectors/note.ts
@@ -38,6 +38,11 @@ export const selectNoteListFetched = createSelector(
   list => list.fetched
 );
 
+export const selectNoteListInitial = createSelector(
+  selectNoteList,
+  list => list.initial
+);
+
 export const selectNoteListFetchedData = createSelector(
   selectNoteList,
   list => list.notes
@@ -71,4 +76,24 @@ export const selectNoteFetchedData = createSelector(
 export const selectNoteFetchError = createSelector(
   selectNoteFetch,
   fetch => fetch.error
+);
+
+export const selectNoteDelete = createSelector(
+  selectNote,
+  note => note.delete
+);
+
+export const selectNoteDeleting = createSelector(
+  selectNoteDelete,
+  del => del.deleting
+);
+
+export const selectNoteDeleted = createSelector(
+  selectNoteDelete,
+  del => del.deleted
+);
+
+export const selectNoteDeleteError = createSelector(
+  selectNoteDelete,
+  del => del.error
 );

--- a/src/services/file.ts
+++ b/src/services/file.ts
@@ -18,3 +18,7 @@ export const fileGet = async (
 ): Promise<object | string | undefined> => {
   return await Storage.vault.get(key);
 };
+
+export const fileDelete = async (key: string): Promise<void> => {
+  await Storage.vault.remove(key);
+};

--- a/src/services/note.ts
+++ b/src/services/note.ts
@@ -1,6 +1,6 @@
 import { API } from 'aws-amplify';
 
-import { fileUpload, fileGet } from 'services/file';
+import { fileUpload, fileGet, fileDelete } from 'services/file';
 
 import INote from 'interfaces/general/note';
 
@@ -34,4 +34,15 @@ export const fetchNote = async (id: string): Promise<INote> => {
   }
 
   return data;
+};
+
+export const deleteNote = async (
+  id: string,
+  fileName?: string
+): Promise<void> => {
+  if (fileName) {
+    await fileDelete(fileName);
+  }
+
+  await API.del(ENDPOINT, `/notes/${id}`, null);
 };

--- a/src/store/actions/note.ts
+++ b/src/store/actions/note.ts
@@ -5,6 +5,10 @@ import {
   ADDED_ERROR_NOTE,
   ADDED_NOTE,
   ADDING_NOTE,
+  DELETE_NOTE,
+  DELETED_ERROR_NOTE,
+  DELETED_NOTE,
+  DELETING_NOTE,
   FETCH_LIST_NOTE,
   FETCH_NOTE,
   FETCHED_ERROR_LIST_NOTE,
@@ -16,18 +20,22 @@ import {
 } from 'store/types/note';
 
 import {
-  IAddNoteAction,
-  IAddedNoteAction,
   IAddedErrorNoteAction,
+  IAddedNoteAction,
   IAddingNoteAction,
-  IFetchListNoteAction,
+  IAddNoteAction,
   IFetchedErrorListNoteAction,
-  IFetchedListNoteAction,
-  IFetchingListNoteAction,
-  IFetchNoteAction,
   IFetchedErrorNoteAction,
+  IFetchedListNoteAction,
   IFetchedNoteAction,
-  IFetchingNoteAction
+  IFetchingListNoteAction,
+  IFetchingNoteAction,
+  IFetchListNoteAction,
+  IFetchNoteAction,
+  IDeletedErrorNoteAction,
+  IDeletedNoteAction,
+  IDeleteNoteAction,
+  IDeletingNoteAction
 } from 'interfaces/actions/note';
 
 export const addNote = (note: string, attachment?: File): IAddNoteAction => {
@@ -37,9 +45,10 @@ export const addNote = (note: string, attachment?: File): IAddNoteAction => {
   };
 };
 
-export const addedNote = (): IAddedNoteAction => {
+export const addedNote = (added?: boolean): IAddedNoteAction => {
   return {
-    type: ADDED_NOTE
+    type: ADDED_NOTE,
+    payload: added
   };
 };
 
@@ -56,9 +65,10 @@ export const addingNote = (): IAddingNoteAction => {
   };
 };
 
-export const fetchListNote = (): IFetchListNoteAction => {
+export const fetchListNote = (initial?: boolean): IFetchListNoteAction => {
   return {
-    type: FETCH_LIST_NOTE
+    type: FETCH_LIST_NOTE,
+    payload: initial
   };
 };
 
@@ -71,10 +81,13 @@ export const fetchedErrorListNote = (
   };
 };
 
-export const fetchedListNote = (notes: INote[]): IFetchedListNoteAction => {
+export const fetchedListNote = (
+  notes: INote[],
+  fetched?: boolean
+): IFetchedListNoteAction => {
   return {
     type: FETCHED_LIST_NOTE,
-    payload: notes
+    payload: { notes, fetched }
   };
 };
 
@@ -108,5 +121,38 @@ export const fetchedNote = (note: INote): IFetchedNoteAction => {
 export const fetchingNote = (): IFetchingNoteAction => {
   return {
     type: FETCHING_NOTE
+  };
+};
+
+export const deleteNote = (
+  id: string,
+  fileName?: string
+): IDeleteNoteAction => {
+  return {
+    type: DELETE_NOTE,
+    payload: {
+      id,
+      fileName
+    }
+  };
+};
+
+export const deletedErrorNote = (error: string): IDeletedErrorNoteAction => {
+  return {
+    type: DELETED_ERROR_NOTE,
+    payload: error
+  };
+};
+
+export const deletedNote = (deleted?: boolean): IDeletedNoteAction => {
+  return {
+    type: DELETED_NOTE,
+    payload: deleted
+  };
+};
+
+export const deletingNote = (): IDeletingNoteAction => {
+  return {
+    type: DELETING_NOTE
   };
 };

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -1,0 +1,27 @@
+import { createStore, applyMiddleware } from 'redux';
+import createSagaMiddleware from 'redux-saga';
+import { composeWithDevTools } from 'redux-devtools-extension';
+import { routerMiddleware } from 'connected-react-router';
+import { createBrowserHistory } from 'history';
+
+import sagas from 'store/sagas';
+import reducers from 'store/reducers';
+
+export const history = createBrowserHistory();
+
+const configureStore = () => {
+  const sagaMiddleware = createSagaMiddleware();
+  const routeMiddleware = routerMiddleware(history);
+
+  const enhancer = composeWithDevTools(
+    applyMiddleware(routeMiddleware, sagaMiddleware)
+  );
+
+  const store = createStore(reducers(history), enhancer);
+
+  sagaMiddleware.run(sagas);
+
+  return store;
+};
+
+export default configureStore;

--- a/src/store/reducers/index.ts
+++ b/src/store/reducers/index.ts
@@ -1,13 +1,29 @@
+import { Reducer } from 'react';
 import { combineReducers } from 'redux';
+import { History } from 'history';
+import {
+  connectRouter,
+  RouterState,
+  LocationChangeAction
+} from 'connected-react-router';
+
+import IAuthState from 'interfaces/state/auth';
+import INoteState from 'interfaces/state/note';
 
 import authReducer from 'store/reducers/auth';
 import noteReducer from 'store/reducers/note';
 
-const reducers = combineReducers({
-  auth: authReducer,
-  note: noteReducer
-});
+const reducers = (history: History) =>
+  combineReducers({
+    router: connectRouter(history),
+    auth: authReducer,
+    note: noteReducer
+  });
 
 export default reducers;
 
-export type state = ReturnType<typeof reducers>;
+export type state = {
+  router: Reducer<RouterState, LocationChangeAction>;
+  auth: IAuthState;
+  note: INoteState;
+};

--- a/src/store/reducers/note.ts
+++ b/src/store/reducers/note.ts
@@ -2,18 +2,23 @@ import {
   ADDED_ERROR_NOTE,
   ADDED_NOTE,
   ADDING_NOTE,
+  DELETED_ERROR_NOTE,
+  DELETED_NOTE,
+  DELETING_NOTE,
   FETCHED_ERROR_LIST_NOTE,
   FETCHED_ERROR_NOTE,
   FETCHED_LIST_NOTE,
   FETCHED_NOTE,
   FETCHING_LIST_NOTE,
-  FETCHING_NOTE
+  FETCHING_NOTE,
+  FETCH_LIST_NOTE
 } from 'store/types/note';
 
 import {
   NoteAddActionTypesTs,
   NoteFetchActionTypesTs,
-  NoteFetchListActionTypesTs
+  NoteFetchListActionTypesTs,
+  NoteDeleteActionTypesTs
 } from 'types/actions/note';
 
 import INoteState from 'interfaces/state/note';
@@ -25,13 +30,16 @@ const INIT_STATE_ADD: INoteState['add'] = {
   error: ''
 };
 
-const add = (
+const addNote = (
   state = INIT_STATE_ADD,
   action: NoteAddActionTypesTs
 ): INoteState['add'] => {
   switch (action.type) {
     case ADDED_NOTE:
-      return { ...INIT_STATE_ADD, added: true };
+      return {
+        ...INIT_STATE_ADD,
+        added: action.payload === undefined ? true : action.payload
+      };
 
     case ADDED_ERROR_NOTE:
       return { ...INIT_STATE_ADD, error: action.payload };
@@ -48,22 +56,36 @@ const INIT_STATE_LIST: INoteState['list'] = {
   fetching: false,
   fetched: false,
   error: '',
+  initial: false,
   notes: []
 };
 
-const list = (
+const listNote = (
   state = INIT_STATE_LIST,
   action: NoteFetchListActionTypesTs
 ): INoteState['list'] => {
   switch (action.type) {
+    case FETCH_LIST_NOTE:
+      return { ...INIT_STATE_LIST, initial: true };
+
     case FETCHED_ERROR_LIST_NOTE:
-      return { ...INIT_STATE_LIST, error: action.payload };
+      return {
+        ...INIT_STATE_LIST,
+        initial: state.initial,
+        error: action.payload
+      };
 
     case FETCHED_LIST_NOTE:
-      return { ...INIT_STATE_LIST, fetched: true, notes: action.payload };
+      return {
+        ...INIT_STATE_LIST,
+        initial: state.initial,
+        fetched:
+          action.payload.fetched === undefined ? true : action.payload.fetched,
+        notes: action.payload.notes
+      };
 
     case FETCHING_LIST_NOTE:
-      return { ...INIT_STATE_LIST, fetching: true };
+      return { ...INIT_STATE_LIST, initial: state.initial, fetching: true };
 
     default:
       return state;
@@ -77,7 +99,7 @@ const INIT_STATE_FETCH: INoteState['fetch'] = {
   note: undefined
 };
 
-const fetch = (
+const fetchNote = (
   state = INIT_STATE_FETCH,
   action: NoteFetchActionTypesTs
 ): INoteState['fetch'] => {
@@ -96,8 +118,37 @@ const fetch = (
   }
 };
 
+const INIT_STATE_DELETE = {
+  deleting: false,
+  deleted: false,
+  error: ''
+};
+
+const deleteNote = (
+  state = INIT_STATE_DELETE,
+  action: NoteDeleteActionTypesTs
+): INoteState['delete'] => {
+  switch (action.type) {
+    case DELETED_ERROR_NOTE:
+      return { ...INIT_STATE_DELETE, error: action.payload };
+
+    case DELETED_NOTE:
+      return {
+        ...INIT_STATE_DELETE,
+        deleted: action.payload === undefined ? true : action.payload
+      };
+
+    case DELETING_NOTE:
+      return { ...INIT_STATE_DELETE, deleting: true };
+
+    default:
+      return state;
+  }
+};
+
 export default combineReducers<INoteState>({
-  add,
-  list,
-  fetch
+  add: addNote,
+  fetch: fetchNote,
+  list: listNote,
+  delete: deleteNote
 });

--- a/src/store/sagas/note.ts
+++ b/src/store/sagas/note.ts
@@ -1,29 +1,47 @@
-import { call, fork, put, takeLatest } from 'redux-saga/effects';
+import { call, fork, put, takeLatest, takeEvery } from 'redux-saga/effects';
+import { push } from 'connected-react-router';
 
-import { addNote, fetchNotes, fetchNote } from 'services/note';
+import { addNote, fetchNotes, fetchNote, deleteNote } from 'services/note';
 
-import { ADD_NOTE, FETCH_LIST_NOTE, FETCH_NOTE } from 'store/types/note';
+import {
+  ADD_NOTE,
+  DELETE_NOTE,
+  FETCH_LIST_NOTE,
+  FETCH_NOTE,
+  DELETED_NOTE,
+  ADDED_NOTE
+} from 'store/types/note';
 
 import {
   addedErrorNote,
   addedNote,
   addingNote,
+  deletedErrorNote,
+  deletedNote,
+  deletingNote,
   fetchedErrorListNote,
   fetchedErrorNote,
   fetchedListNote,
   fetchedNote,
   fetchingListNote,
-  fetchingNote
+  fetchingNote,
+  fetchListNote
 } from 'store/actions/note';
 
 import INote from 'interfaces/general/note';
 
-import { IAddNoteAction, IFetchNoteAction } from 'interfaces/actions/note';
+import {
+  IAddNoteAction,
+  IDeleteNoteAction,
+  IFetchNoteAction
+} from 'interfaces/actions/note';
 
 export default [
   fork(addNoteSaga),
+  fork(deleteNoteSaga),
   fork(fetchListNoteSaga),
-  fork(fetchNoteSaga)
+  fork(fetchNoteSaga),
+  fork(listenNoteSaga)
 ];
 
 function* addNoteSaga() {
@@ -32,8 +50,8 @@ function* addNoteSaga() {
 
 function* callAddNoteSaga({ payload }: IAddNoteAction) {
   try {
-    const { note, attachment } = payload;
     yield put(addingNote());
+    const { note, attachment } = payload;
     yield call(addNote, note, attachment);
     yield put(addedNote());
   } catch (err) {
@@ -67,4 +85,28 @@ function* callFetchNoteSaga({ payload }: IFetchNoteAction) {
   } catch (err) {
     yield put(fetchedErrorNote(err.message));
   }
+}
+
+function* deleteNoteSaga() {
+  yield takeLatest(DELETE_NOTE, callDeleteNoteSaga);
+}
+
+function* callDeleteNoteSaga({ payload }: IDeleteNoteAction) {
+  try {
+    yield put(deletingNote());
+    const { id, fileName } = payload;
+    yield call(deleteNote, id, fileName);
+    yield put(deletedNote());
+  } catch (err) {
+    yield put(deletedErrorNote(err.message));
+  }
+}
+
+function* listenNoteSaga() {
+  yield takeEvery([DELETED_NOTE, ADDED_NOTE], callListenNoteSaga);
+}
+
+function* callListenNoteSaga() {
+  yield put(fetchListNote());
+  yield put(push('/'));
 }

--- a/src/store/types/note.ts
+++ b/src/store/types/note.ts
@@ -12,3 +12,8 @@ export const FETCH_NOTE = '@note/FETCH';
 export const FETCHED_ERROR_NOTE = '@note/FETCHED_ERROR';
 export const FETCHED_NOTE = '@note/FETCHED';
 export const FETCHING_NOTE = '@note/FETCHING';
+
+export const DELETE_NOTE = '@note/DELETE';
+export const DELETED_ERROR_NOTE = '@note/DELETED_ERROR';
+export const DELETED_NOTE = '@note/DELETED';
+export const DELETING_NOTE = '@note/DELETING';

--- a/src/types/actions/note.ts
+++ b/src/types/actions/note.ts
@@ -3,6 +3,10 @@ import {
   IAddedNoteAction,
   IAddingNoteAction,
   IAddNoteAction,
+  IDeletedErrorNoteAction,
+  IDeletedNoteAction,
+  IDeleteNoteAction,
+  IDeletingNoteAction,
   IFetchedErrorListNoteAction,
   IFetchedErrorNoteAction,
   IFetchedListNoteAction,
@@ -30,3 +34,9 @@ export type NoteFetchActionTypesTs =
   | IFetchedNoteAction
   | IFetchingNoteAction
   | IFetchNoteAction;
+
+export type NoteDeleteActionTypesTs =
+  | IDeleteNoteAction
+  | IDeletedErrorNoteAction
+  | IDeletedNoteAction
+  | IDeletingNoteAction;


### PR DESCRIPTION
Feature
- Note deletion (actions types, actions, state, interface, saga, service)

Refactored
- Used `connected-react-router` for using `push` on `saga` directly rather than depending on the component level using `useEffect(() => changed ? push('/'), [changed])`. Easier to maintain and easier to track down logic.